### PR TITLE
Implement Claw state machine

### DIFF
--- a/robot/src/main/java/frc/robot/Constants.java
+++ b/robot/src/main/java/frc/robot/Constants.java
@@ -27,11 +27,16 @@ public class Constants {
 
     public static class Claw {
         public static final int kIntakeId = 5;
+        public static final int kClawSolenoidId = 0;
+
         public static final double kCargoIntakeSpeed = -.4;
         public static final double kCargoExhaustSpeed = .4;
 
         public static final double kHatchIntakeSpeed = .3;
         public static final double kHatchExhaustSpeed = -.3;
+
+        public static final double kCargoHoldSpeed = -.1;
+        public static final double kHatchHoldSpeed = .1;
     }
 
     // --- Gamepad Constants ---

--- a/robot/src/main/java/frc/robot/OI.java
+++ b/robot/src/main/java/frc/robot/OI.java
@@ -11,7 +11,6 @@ import frc.robot.controllers.XboxController;
 import frc.robot.subsystems.Claw;
 import frc.robot.commands.SetClawTargetMode;
 import frc.robot.commands.SetClawSpinMode;
-import edu.wpi.first.wpilibj.GenericHID.Hand;
 
 
 /**

--- a/robot/src/main/java/frc/robot/Robot.java
+++ b/robot/src/main/java/frc/robot/Robot.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.subsystems.Claw;
 import frc.robot.subsystems.Drivetrain;
 
 /**
@@ -57,6 +58,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotPeriodic() {
+    Claw.getInstance().updateDashboard();
   }
 
   /**

--- a/robot/src/main/java/frc/robot/commands/ClawDefaultCommand.java
+++ b/robot/src/main/java/frc/robot/commands/ClawDefaultCommand.java
@@ -1,0 +1,81 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.subsystems.Claw;
+import frc.robot.subsystems.Claw.ControlMode;
+import frc.robot.subsystems.Claw.SpinMode;
+import frc.robot.subsystems.Claw.TargetMode;
+
+public class ClawDefaultCommand extends Command {
+    private Claw mClaw;
+
+    public ClawDefaultCommand() {
+        mClaw = Claw.getInstance();
+
+        requires(mClaw);
+    }
+
+    // Called just before this Command runs the first time
+    @Override
+    protected void initialize() {
+        System.out.println("initializing claw state machine");
+    }
+
+    // Called repeatedly when this Command is scheduled to run
+    @Override
+    protected void execute() {
+        if (mClaw.getTargetMode() == TargetMode.CARGO) {
+            // If the claw is in automatic mode (i.e. no input), determine the speeds
+            if (mClaw.getControlMode() == ControlMode.AUTO) {
+                // If there is cargo loaded, HOLD it
+                if (mClaw.cargoLeftPresent() && mClaw.cargoRightPresent()) {
+                    mClaw.setSpinMode(SpinMode.HOLD);
+                }
+                else {
+                    mClaw.setSpinMode(SpinMode.STOP);
+                }
+            }
+            // Otherwise we just use the ensureMode functionality to correctly spin
+        }
+        else if (mClaw.getTargetMode() == TargetMode.HATCH) {
+            // If the claw is in automatic mode (i.e. no input), determine the speeds
+            if (mClaw.getControlMode() == ControlMode.AUTO) {
+                // If there is cargo loaded, HOLD it
+                if (mClaw.hatchLeftPresent() && mClaw.hatchRightPresent()) {
+                    mClaw.setSpinMode(SpinMode.HOLD);
+                }
+                else {
+                    mClaw.setSpinMode(SpinMode.STOP);
+                }
+            }
+            // Otherwise we just use the ensureMode functionality to correctly spin
+        }
+
+        // Make the appropriate adjustments
+        mClaw.ensureMode();
+    }
+
+    // Make this return true when this Command no longer needs to run execute()
+    @Override
+    protected boolean isFinished() {
+        return false;
+    }
+
+    // Called once after isFinished returns true
+    @Override
+    protected void end() {
+    }
+
+    // Called when another command which requires one or more of the same
+    // subsystems is scheduled to run
+    @Override
+    protected void interrupted() {
+    }
+}

--- a/robot/src/main/java/frc/robot/commands/SetClawSpinMode.java
+++ b/robot/src/main/java/frc/robot/commands/SetClawSpinMode.java
@@ -9,57 +9,60 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.subsystems.Claw;
+import frc.robot.subsystems.Claw.ControlMode;
+import frc.robot.subsystems.Claw.SpinMode;
 
 /**
  * Set the claw spin mode and initiate the action
  * based on the current target mode
  */
 public class SetClawSpinMode extends Command {
-  // Keep an instance of the drivetrain around
-  private Claw mClaw;
-  private Claw.SpinMode mMode;
+    // Keep an instance of the drivetrain around
+    private Claw mClaw;
+    private Claw.SpinMode mMode;
 
-  public SetClawSpinMode(Claw.SpinMode mode) {
-    mClaw = Claw.getInstance();
-    mMode = mode;
-    requires(mClaw);
-  }
+    public SetClawSpinMode(Claw.SpinMode mode) {
+        mClaw = Claw.getInstance();
+        mMode = mode;
+    }
 
-  // Called just before this Command runs the first time
-  @Override
-  protected void initialize() {
-    System.out.println("Starting SetClawSpinMode");
-    this.mClaw.setSpinMode(this.mMode);
-    this.mClaw.ensureMode();
-  }
+    // Called just before this Command runs the first time
+    @Override
+    protected void initialize() {
+        System.out.println("Starting SetClawSpinMode");
+        this.mClaw.setControlMode(ControlMode.MANUAL);
+        this.mClaw.setSpinMode(this.mMode);
+        this.mClaw.ensureMode();
+    }
 
-  // Called repeatedly when this Command is scheduled to run
-  // This is blank because the comment is called continuously by
-  // the button that is connected to it
-  @Override
-  protected void execute() {
+    // Called repeatedly when this Command is scheduled to run
+    // This is blank because the comment is called continuously by
+    // the button that is connected to it
+    @Override
+    protected void execute() {
     
-  }
+    }
 
-  // Make this return true when this Command no longer needs to run execute()
-  // This only ends when killed by the button its connected to
-  @Override
-  protected boolean isFinished() {
-    return false;
-  }
+    // Make this return true when this Command no longer needs to run execute()
+    // This only ends when killed by the button its connected to
+    @Override
+    protected boolean isFinished() {
+        return false;
+    }
 
-  // Called once after isFinished returns true
-  @Override
-  protected void end() {
-    System.out.println("Ending SetClawSpinMode");
-    this.mClaw.stop();
-  }
+    // Called once after isFinished returns true
+    @Override
+    protected void end() {
+        System.out.println("Ending SetClawSpinMode");
+        // when this command ends, the speeds should be automatically set
+        this.mClaw.setControlMode(ControlMode.AUTO);
+        this.mClaw.ensureMode();
+    }
 
-  // Called when another command which requires one or more of the same
-  // subsystems is scheduled to run
-  @Override
-  protected void interrupted() {
-    System.out.println("IEnding SetClawSpinMode");
-    this.mClaw.stop();
-  }
+    // Called when another command which requires one or more of the same
+    // subsystems is scheduled to run
+    @Override
+    protected void interrupted() {
+        end();
+    }
 }

--- a/robot/src/main/java/frc/robot/commands/SetClawTargetMode.java
+++ b/robot/src/main/java/frc/robot/commands/SetClawTargetMode.java
@@ -12,44 +12,43 @@ import frc.robot.subsystems.Claw;
 
 public class SetClawTargetMode extends Command {
 
-  // Keep an instance of the drivetrain around
-  private Claw mClaw;
-  private Claw.TargetMode mMode;
+    // Keep an instance of the drivetrain around
+    private Claw mClaw;
+    private Claw.TargetMode mMode;
 
-  public SetClawTargetMode(Claw.TargetMode mode) {
-    mClaw = Claw.getInstance();
-    mMode = mode;
-    requires(mClaw);
-  }
+    public SetClawTargetMode(Claw.TargetMode mode) {
+        mClaw = Claw.getInstance();
+        mMode = mode;
+    }
 
-  // Called just before this Command runs the first time
-  @Override
-  protected void initialize() {
-    System.out.println("Starting SetClawTargetMode");
-  }
+    // Called just before this Command runs the first time
+    @Override
+    protected void initialize() {
+        System.out.println("Starting SetClawTargetMode");
+    }
 
-  // Called repeatedly when this Command is scheduled to run
-  @Override
-  protected void execute() {
-    this.mClaw.setTargetMode(this.mMode);
-  }
+    // Called repeatedly when this Command is scheduled to run
+    @Override
+    protected void execute() {
+        this.mClaw.setTargetMode(this.mMode);
+    }
 
-  // Make this return true when this Command no longer needs to run execute()
-  @Override
-  protected boolean isFinished() {
-    return true;
-  }
+    // Make this return true when this Command no longer needs to run execute()
+    @Override
+    protected boolean isFinished() {
+        return true;
+    }
 
-  // Called once after isFinished returns true
-  @Override
-  protected void end() {
-    System.out.println("Ending SetClawTargetMode");
-  }
+    // Called once after isFinished returns true
+    @Override
+    protected void end() {
+        System.out.println("Ending SetClawTargetMode");
+    }
 
-  // Called when another command which requires one or more of the same
-  // subsystems is scheduled to run
-  @Override
-  protected void interrupted() {
-    System.out.println("IEnding SetClawTargetMode");
-  }
+    // Called when another command which requires one or more of the same
+    // subsystems is scheduled to run
+    @Override
+    protected void interrupted() {
+        System.out.println("IEnding SetClawTargetMode");
+    }
 }

--- a/robot/src/main/java/frc/robot/subsystems/Claw.java
+++ b/robot/src/main/java/frc/robot/subsystems/Claw.java
@@ -7,12 +7,16 @@
 
 package frc.robot.subsystems;
 
+import com.ctre.phoenix.CANifier;
+import com.ctre.phoenix.CANifier.GeneralPin;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
+import edu.wpi.first.wpilibj.Solenoid;
 import edu.wpi.first.wpilibj.command.Subsystem;
-
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
+import frc.robot.commands.ClawDefaultCommand;
 
 /**
  * The Claw represents the subsystem responsible for collecting, holding, and 
@@ -24,127 +28,219 @@ import frc.robot.Constants;
  */
 public class Claw extends Subsystem {
 
-  // Generally, return a singleton instance of the subsystem
-  private static Claw sInstance;
+    // Generally, return a singleton instance of the subsystem
+    private static Claw sInstance;
 
-  // Always return the same instance
-  public static Claw getInstance() {
-    if (sInstance == null) {
-      sInstance = new Claw();
+    // Always return the same instance
+    public static Claw getInstance() {
+        if (sInstance == null) {
+        sInstance = new Claw();
+        }
+
+        return sInstance;
     }
 
-    return sInstance;
-  }
-
-  // TargetMode tracks what the current target type is, to 
-  // determine if the claw should be open or closed
-  public static enum TargetMode {
-    HATCH,
-    CARGO
-  }
-
-  // SpinMode tracks what the current action of the collection
-  // wheels should be, based on the mTargetMode variable
-  public static enum SpinMode {
-    INTAKE,
-    EXHAUST,
-    STOP
-  }
-
-  // Motor controller declarations
-  private CANSparkMax mIntakeControl;
-
-  // Start in the open position
-  private TargetMode mTargetMode = TargetMode.CARGO;
-
-  // Start with the collection wheels not moving
-  private SpinMode mSpinMode = SpinMode.STOP;
-
-  private Claw() {
-    mIntakeControl = new CANSparkMax(Constants.Claw.kIntakeId, MotorType.kBrushless);
-    this.ensureMode();
-  }
-
-  /**
-   * This is currently not used as the mode selections are managed
-   * by the default variables and controllers
-   */
-  @Override
-  public void initDefaultCommand() {
-    // Set the default command for a subsystem here.
-    // setDefaultCommand(new MySpecialCommand());
-  }
-
-  /**
-   * Reset the built in encoders on the SPARK Max-s
-   * 
-   * Resetting the encoders is useful when you're about to perform an autonomous
-   * driving routine, as errors could have built up between now and the last time
-   * you reset them.
-   */
-  public void resetEncoders() {
-    // To reset the encoders, we just set their current positions to 0
-    mIntakeControl.getEncoder().setPosition(0.0);
-  }
-
-  /**
-   * Set the speed of the intake motors, between [-1.0, 1.0]
-   * Negative speed results in inverse direction
-   *
-   * @param speed the speed to set the motors at
-   */
-  public void setRawIntakeSpeed(double speed) {
-    mIntakeControl.set(speed);
-  }
-
-  /**
-   * Set the target tracking mode, which will 
-   * adjust the position of the claw
-   * @param mode
-   */
-  public void setTargetMode(TargetMode mode) {
-    this.mTargetMode = mode;
-  }
-
-  /**
-   * Set the spin mode, which will adjust the speed of 
-   * the collection wheels based on the targetMode
-   * @param mode
-   */
-  public void setSpinMode(SpinMode mode) {
-    this.mSpinMode = mode;
-  }
-
-  /**
-   * ensureMode sets the claw and the collection wheels to the 
-   * proper orientation based on the target and spin modes.
-   * 
-   * It should be called once every time an update is made to 
-   * one of the modes.
-   */
-  public void ensureMode() {
-    double speed = 0;
-    if (mTargetMode == TargetMode.CARGO) {
-      speed = mSpinMode == SpinMode.INTAKE ? Constants.Claw.kCargoIntakeSpeed : Constants.Claw.kCargoExhaustSpeed;
-    } else if (mTargetMode == TargetMode.HATCH) {
-      speed = mSpinMode == SpinMode.INTAKE ? Constants.Claw.kHatchIntakeSpeed : Constants.Claw.kHatchExhaustSpeed;
-    } else {
-      System.out.println("Invalid mode");
+    // TargetMode tracks what the current target type is, to 
+    // determine if the claw should be open or closed
+    public static enum TargetMode {
+        HATCH,
+        CARGO
     }
-    if (mSpinMode == SpinMode.STOP) {
-      speed = 0;
-    }
-    System.out.println(speed);
-    this.setRawIntakeSpeed(speed);
-  }
 
-  /**
-   * Stop the collection wheels from spinning
-   */
-  public void stop() {
-    this.setSpinMode(SpinMode.STOP);
-    this.ensureMode();
-  }
+    // SpinMode tracks what the current action of the collection
+    // wheels should be, based on the mTargetMode variable
+    public static enum SpinMode {
+        INTAKE,
+        EXHAUST,
+        STOP,
+        HOLD,
+    }
+
+    // Determine the current control mode of the claw. If in AUTO
+    // mode, the claw intake wheels will spin/not spin depending on 
+    // the presence of a game item
+    public static enum ControlMode {
+        AUTO,
+        MANUAL
+    }
+
+    // Motor controller declarations
+    private CANSparkMax mIntakeControl;
+
+    // CANifier for the onboard sensors
+    private CANifier mSensors;
+
+    private Solenoid mClawSolenoid;
+
+    // Start in the open position
+    private TargetMode mTargetMode = TargetMode.CARGO;
+
+    // Automatic spin mode
+    private SpinMode mSpinMode = SpinMode.STOP;
+
+    private ControlMode mControlMode = ControlMode.AUTO;
+
+    private Claw() {
+        mIntakeControl = new CANSparkMax(Constants.Claw.kIntakeId, MotorType.kBrushless);
+        mSensors = new CANifier(0);
+        mClawSolenoid = new Solenoid(Constants.Claw.kClawSolenoidId);
+
+        this.ensureMode();
+    }
+
+    @Override
+    public void initDefaultCommand() {
+        setDefaultCommand(new ClawDefaultCommand());
+    }
+
+    /**
+     * Reset the built in encoders on the SPARK Max-s
+     * 
+     * Resetting the encoders is useful when you're about to perform an autonomous
+     * driving routine, as errors could have built up between now and the last time
+     * you reset them.
+     */
+    public void resetEncoders() {
+        // To reset the encoders, we just set their current positions to 0
+        mIntakeControl.getEncoder().setPosition(0.0);
+    }
+
+    /**
+     * Set the speed of the intake motors, between [-1.0, 1.0]
+     * Negative speed results in inverse direction
+     *
+     * @param speed the speed to set the motors at
+     */
+    public void setRawIntakeSpeed(double speed) {
+        mIntakeControl.set(speed);
+    }
+
+    /**
+     * Set the target tracking mode, which will 
+     * adjust the position of the claw
+     * @param mode
+     */
+    public void setTargetMode(TargetMode mode) {
+        this.mTargetMode = mode;
+    }
+
+    /**
+     * Set the spin mode, which will adjust the speed of 
+     * the collection wheels based on the targetMode
+     * @param mode
+     */
+    public void setSpinMode(SpinMode mode) {
+        this.mSpinMode = mode;
+    }
+
+    public void setControlMode(ControlMode mode) {
+        this.mControlMode = mode;
+    }
+
+    /**
+     * ensureMode sets the claw and the collection wheels to the 
+     * proper orientation based on the target and spin modes.
+     * 
+     * It should be called once every time an update is made to 
+     * one of the modes.
+     */
+    public void ensureMode() {
+        double speed = 0;
+        if (mTargetMode == TargetMode.CARGO) {
+            switch (mSpinMode) {
+                case INTAKE:
+                    speed = Constants.Claw.kCargoIntakeSpeed;
+                    break;
+                case EXHAUST:
+                    speed = Constants.Claw.kCargoExhaustSpeed;
+                    break;
+                case HOLD:
+                    speed = Constants.Claw.kCargoHoldSpeed;
+                    break;
+                default: 
+                    speed = 0;
+            }
+            
+        } else if (mTargetMode == TargetMode.HATCH) {
+            switch (mSpinMode) {
+                case INTAKE:
+                    speed = Constants.Claw.kHatchIntakeSpeed;
+                    break;
+                case EXHAUST:
+                    speed = Constants.Claw.kHatchExhaustSpeed;
+                    break;
+                case HOLD:
+                    speed = Constants.Claw.kHatchHoldSpeed;
+                    break;
+                default: 
+                    speed = 0;
+            }
+        } else {
+            System.out.println("Invalid mode");
+        }
+
+        if (mSpinMode == SpinMode.STOP) {
+            speed = 0;
+        }
+        
+        this.setRawIntakeSpeed(speed);
+
+        // Handle the solenoid
+        if (mTargetMode == TargetMode.HATCH && !mClawSolenoid.get()) {
+            mClawSolenoid.set(true);
+        }
+        else if (mTargetMode == TargetMode.CARGO && mClawSolenoid.get()) {
+            mClawSolenoid.set(false);
+        }
+    }
+
+    /**
+     * Stop the collection wheels from spinning
+     */
+    public void stop() {
+        this.setSpinMode(SpinMode.STOP);
+        this.ensureMode();
+    }
+
+    public TargetMode getTargetMode() {
+        return this.mTargetMode;
+    }
+
+    public SpinMode getSpinMode() {
+        return this.mSpinMode;
+    }
+
+    public ControlMode getControlMode() {
+        return this.mControlMode;
+    }
+
+    public boolean hatchLeftPresent() {
+        return mSensors.getGeneralInput(GeneralPin.LIMF);
+    }
+
+    public boolean hatchRightPresent() {
+        return mSensors.getGeneralInput(GeneralPin.LIMR);
+    }
+
+    public boolean cargoLeftPresent() {
+        // Flipped because the distance sensor is HIGH normally
+        return !mSensors.getGeneralInput(GeneralPin.QUAD_A);
+    }
+
+    public boolean cargoRightPresent() {
+        return !mSensors.getGeneralInput(GeneralPin.QUAD_B);
+    }
+
+    public void updateDashboard() {
+        SmartDashboard.putString("Claw Control Mode", getControlMode().toString());
+        SmartDashboard.putString("Claw Target Mode", getTargetMode().toString());
+        SmartDashboard.putString("Claw Spin Mode", getSpinMode().toString());
+
+        SmartDashboard.putBoolean("Claw Left Hatch Sensor", hatchLeftPresent());
+        SmartDashboard.putBoolean("Claw Right Hatch Sensor", hatchRightPresent());
+        SmartDashboard.putBoolean("Claw Left Cargo Sensor", cargoLeftPresent());
+        SmartDashboard.putBoolean("Claw Right Cargo Sensor", cargoRightPresent());
+    }
 }
 
 //                               hMMMMM-                                               


### PR DESCRIPTION
This commit implements a default command for the Claw which provides a
"state machine" that automatically sets the appropriate speeds and
solenoid settings for a given mode.

Commands to switch modes/speeds merely have to set the appropriate
modes, and the state machine will take care of the rest.